### PR TITLE
Apply the changes in a separate job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     name: Apply to production
     runs-on: ubuntu-latest
     needs: [build]
-    if: github.event_name == 'merge_queue'
+    if: github.event_name == 'merge_group'
 
     permissions:
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,14 +4,12 @@ on:
   pull_request:
   merge_group:
 
-permissions:
-  contents: read
-  id-token: write
-
 jobs:
-  ci:
-    name: CI
+  build:
+    name: Build and test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout the source code
         uses: actions/checkout@v4
@@ -19,12 +17,64 @@ jobs:
       - name: Check formatting
         run: cargo fmt --check
 
+      - name: Build the tool
+        run: cargo build
+
+      - name: Try a dry run of the changes
+        run: cargo run -- --skip-upload
+        if: github.event_name == 'pull_request'
+
+      - name: Upload tool to artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: tool
+          path: target/debug/ci-mirrors
+          if-no-files-found: error
+
+      - name: Upload files.toml to artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: files-manifest
+          path: files.toml
+          if-no-files-found: error
+
+  apply:
+    name: Apply to production
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: github.event_name == 'merge_queue'
+
+    permissions:
+      id-token: write
+    environment:
+      name: upload
+      url: https://ci-mirrors.rust-lang.org
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+
       - name: Authenticate with AWS
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: us-west-1
           role-to-assume: arn:aws:iam::890664054962:role/ci--rust-lang--ci-mirrors
-        if: github.event_name != 'pull_request'
+
+      - name: Mark the tool as executable
+        run: chmod +x ./ci-mirrors
 
       - name: Run the tool
-        run: "cargo run -- ${{ github.event_name == 'pull_request' && '--skip-upload' || '' }}"
+        run: ./ci-mirrors
+
+  finished:
+    name: Build finished
+    runs-on: ubuntu-latest
+    needs: [build, apply]
+    if: "${{ !cancelled() }}"
+    env:
+      NEEDS: "${{ toJson(needs) }}"
+    steps:
+      - name: Check if all jobs were successful or skipped
+        run: echo "${NEEDS}" | jq --exit-status 'all(.result == "success" or .result == "skipped")'


### PR DESCRIPTION
This PR changes the CI workflow to apply the changes in a separate job, transferring the binary built in the previous job.

This improves the security of the workflow, since AWS credentials are now granted only to the part of the workflow that applies the changes to our infrastructure. We can also use an environment to restrict even more what can gain access to AWS.