### PR TITLE
Check existing files in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,11 +638,13 @@ dependencies = [
  "aws-config",
  "aws-sdk-s3",
  "clap",
+ "futures",
  "reqwest",
  "serde",
  "sha2",
  "tempfile",
  "tokio",
+ "tokio-util",
  "toml",
 ]
 
@@ -988,6 +990,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1004,10 +1021,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -1027,8 +1066,10 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1907,7 +1948,6 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
- "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.8",
@@ -1934,11 +1974,13 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "tower",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "windows-registry",
 ]
@@ -2463,7 +2505,19 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2771,6 +2825,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,11 @@ anyhow = "1.0.97"
 aws-config = { version = "1.6.1", features = ["behavior-version-latest"] }
 aws-sdk-s3 = "1.82.0"
 clap = { version = "4.5.35", default-features = false, features = ["std", "derive", "help"] }
-reqwest = { version = "0.12.15", features = ["blocking"] }
+futures = "0.3.31"
+reqwest = { version = "0.12.15", features = ["stream"] }
 serde = { version = "1.0.219", features = ["derive"] }
 sha2 = "0.10.8"
 tempfile = "3.19.1"
-tokio = { version = "1.44.1", features = ["rt"] }
+tokio = { version = "1.44.1", features = ["fs", "macros", "rt", "rt-multi-thread"] }
+tokio-util = { version = "0.7.14", features = ["io"] }
 toml = "0.8.20"

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,9 @@ use crate::storage::{CdnReader, FileStatus, S3Storage, Storage};
 use anyhow::Error;
 use clap::Parser;
 use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::Semaphore;
+use tokio::task::JoinSet;
 
 mod downloader;
 mod manifest;
@@ -26,6 +29,9 @@ struct Cli {
     /// Name of the S3 bucket containing the files.
     #[arg(long, default_value = "rust-lang-ci-mirrors")]
     s3_bucket: String,
+
+    #[arg(short, long, default_value = "100")]
+    jobs: usize,
 }
 
 #[tokio::main]
@@ -33,21 +39,39 @@ async fn main() -> Result<(), Error> {
     let args = Cli::parse();
     let manifest = Manifest::load(&args.manifest)?;
 
-    let storage = if args.skip_upload {
+    let storage = Arc::new(if args.skip_upload {
         Storage::ReadOnly(CdnReader::new(args.cdn_url))
     } else {
         Storage::ReadWrite(S3Storage::new(args.s3_bucket).await?)
-    };
+    });
 
     // Collect all errors that happen during the check phase and show them at the end. This way, if
     // there are multiple errors in CI users won't have to retry the build multiple times.
     let mut errors = Vec::new();
 
-    eprintln!("calculating the changes to execute...");
+    eprintln!(
+        "calculating the changes to execute ({} files, {} parallelism)...",
+        manifest.files.len(),
+        args.jobs
+    );
+
+    // Check the status of all files in parallel.
+    let concurrency_limiter = Arc::new(Semaphore::new(args.jobs));
+    let mut taskset = JoinSet::new();
+    for file in manifest.files {
+        let storage = storage.clone();
+        let concurrency_limiter = concurrency_limiter.clone();
+        taskset.spawn(async move {
+            let _permit = concurrency_limiter.acquire().await.unwrap();
+            let status = storage.file_status(&file.name).await;
+            (file, status)
+        });
+    }
+
     let mut to_upload = Vec::new();
-    for file in &manifest.files {
+    for (file, status) in taskset.join_all().await {
         let name = &file.name;
-        match storage.file_status(&file.name).await? {
+        match status? {
             FileStatus::Legacy => errors.push(format!(
                 "file {name} was already uploaded without this tool"
             )),

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -5,7 +5,6 @@ use aws_sdk_s3::operation::head_object::HeadObjectError;
 use aws_sdk_s3::primitives::ByteStream;
 use reqwest::StatusCode;
 use std::path::Path;
-use tokio::runtime::Runtime;
 
 pub(crate) enum Storage {
     ReadOnly(CdnReader),
@@ -13,57 +12,60 @@ pub(crate) enum Storage {
 }
 
 impl Storage {
-    pub(crate) fn file_status(&self, path: &str) -> Result<FileStatus, Error> {
-        if let Some(hash) = self.get_file(&format!("{path}.sha256"))? {
+    pub(crate) async fn file_status(&self, path: &str) -> Result<FileStatus, Error> {
+        if let Some(hash) = self.get_file(&format!("{path}.sha256")).await? {
             Ok(FileStatus::Present {
                 sha256: hash.trim().to_string(),
             })
-        } else if self.file_exists(path)? {
+        } else if self.file_exists(path).await? {
             Ok(FileStatus::Legacy)
         } else {
             Ok(FileStatus::Missing)
         }
     }
 
-    pub(crate) fn upload_file(&self, path: &str, file: &Path) -> Result<(), Error> {
+    pub(crate) async fn upload_file(&self, path: &str, file: &Path) -> Result<(), Error> {
         match self {
             Storage::ReadOnly(_) => panic!("unsupported in read-only mode"),
             Storage::ReadWrite(s3) => {
-                s3.put_object(path, s3.runtime.block_on(ByteStream::from_path(file))?)
+                s3.put_object(path, ByteStream::from_path(file).await?)
+                    .await
             }
         }
     }
 
-    pub(crate) fn write_contents(&self, path: &str, content: &[u8]) -> Result<(), Error> {
+    pub(crate) async fn write_contents(&self, path: &str, content: &[u8]) -> Result<(), Error> {
         match self {
             Storage::ReadOnly(_) => panic!("unsupported in read-only mode"),
-            Storage::ReadWrite(s3) => s3.put_object(path, ByteStream::from(content.to_vec())),
+            Storage::ReadWrite(s3) => {
+                s3.put_object(path, ByteStream::from(content.to_vec()))
+                    .await
+            }
         }
     }
 
-    fn get_file(&self, path: &str) -> Result<Option<String>, Error> {
+    async fn get_file(&self, path: &str) -> Result<Option<String>, Error> {
         match self {
             Storage::ReadOnly(storage) => {
                 let url = format!("{}/{path}", storage.cdn_url);
-                let response = storage.http.get(&url).send()?;
+                let response = storage.http.get(&url).send().await?;
                 match response.status() {
-                    StatusCode::OK => Ok(Some(response.text()?)),
+                    StatusCode::OK => Ok(Some(response.text().await?)),
                     StatusCode::NOT_FOUND | StatusCode::FORBIDDEN => Ok(None),
                     status => bail!("unexpected status {status} when requesting {url}"),
                 }
             }
             Storage::ReadWrite(storage) => {
-                let response = storage.runtime.block_on(
-                    storage
-                        .s3
-                        .get_object()
-                        .bucket(&storage.s3_bucket)
-                        .key(path)
-                        .send(),
-                );
+                let response = storage
+                    .s3
+                    .get_object()
+                    .bucket(&storage.s3_bucket)
+                    .key(path)
+                    .send()
+                    .await;
                 match response {
                     Ok(success) => Ok(Some(String::from_utf8(
-                        storage.runtime.block_on(success.body.collect())?.to_vec(),
+                        success.body.collect().await?.to_vec(),
                     )?)),
                     Err(error) => {
                         if let SdkError::ServiceError(service) = &error {
@@ -78,11 +80,11 @@ impl Storage {
         }
     }
 
-    fn file_exists(&self, path: &str) -> Result<bool, Error> {
+    async fn file_exists(&self, path: &str) -> Result<bool, Error> {
         match self {
             Storage::ReadOnly(storage) => {
                 let url = format!("{}/{path}", storage.cdn_url);
-                let response = storage.http.head(&url).send()?;
+                let response = storage.http.head(&url).send().await?;
                 match response.status() {
                     StatusCode::OK => Ok(true),
                     StatusCode::NOT_FOUND | StatusCode::FORBIDDEN => Ok(false),
@@ -90,14 +92,13 @@ impl Storage {
                 }
             }
             Storage::ReadWrite(storage) => {
-                let response = storage.runtime.block_on(
-                    storage
-                        .s3
-                        .head_object()
-                        .bucket(&storage.s3_bucket)
-                        .key(path)
-                        .send(),
-                );
+                let response = storage
+                    .s3
+                    .head_object()
+                    .bucket(&storage.s3_bucket)
+                    .key(path)
+                    .send()
+                    .await;
                 match response {
                     Ok(_) => Ok(true),
                     Err(error) => {
@@ -115,51 +116,45 @@ impl Storage {
 }
 
 pub(crate) struct CdnReader {
-    http: reqwest::blocking::Client,
+    http: reqwest::Client,
     cdn_url: String,
 }
 
 impl CdnReader {
     pub(crate) fn new(cdn_url: String) -> Self {
         Self {
-            http: reqwest::blocking::Client::new(),
+            http: reqwest::Client::new(),
             cdn_url,
         }
     }
 }
 
 pub(crate) struct S3Storage {
-    runtime: Runtime,
     s3: aws_sdk_s3::Client,
     s3_bucket: String,
 }
 
 impl S3Storage {
-    pub(crate) fn new(s3_bucket: String) -> Result<Self, Error> {
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()?;
-        let config = runtime.block_on(aws_config::load_from_env());
+    pub(crate) async fn new(s3_bucket: String) -> Result<Self, Error> {
+        let config = aws_config::load_from_env().await;
         Ok(S3Storage {
-            runtime,
             s3: aws_sdk_s3::Client::new(&config),
             s3_bucket,
         })
     }
 
-    fn put_object(&self, key: &str, body: ByteStream) -> Result<(), Error> {
-        self.runtime.block_on(
-            self.s3
-                .put_object()
-                .bucket(&self.s3_bucket)
-                .key(key)
-                .body(body)
-                // Prevent overriding an existing file. Note that the IAM policy used to upload
-                // objects in CI *enforces* the present of this line. If you remove it without
-                // first changing the policy, the request will fail.
-                .if_none_match("*")
-                .send(),
-        )?;
+    async fn put_object(&self, key: &str, body: ByteStream) -> Result<(), Error> {
+        self.s3
+            .put_object()
+            .bucket(&self.s3_bucket)
+            .key(key)
+            .body(body)
+            // Prevent overriding an existing file. Note that the IAM policy used to upload
+            // objects in CI *enforces* the present of this line. If you remove it without
+            // first changing the policy, the request will fail.
+            .if_none_match("*")
+            .send()
+            .await?;
         Ok(())
     }
 }


### PR DESCRIPTION
This PR migrates the codebase to async, and adds parallelism when checking the status of existing files. That is the only step currently parallelized as it's the only one I expect to be large: downloading new files and uploading them would only happen for files added by the PR being processed, which should always be a reasonable number.