### PR TITLE
Add a command for adding entries to TOML files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         run: cargo build
 
       - name: Try a dry run of the changes
-        run: cargo run -- --skip-upload
+        run: cargo run -- upload --skip-upload
         if: github.event_name == 'pull_request'
 
       - name: Upload tool to artifacts
@@ -41,7 +41,7 @@ jobs:
   apply:
     name: Apply to production
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [ build ]
     if: github.event_name == 'merge_group'
 
     permissions:
@@ -72,12 +72,12 @@ jobs:
         run: chmod +x ./ci-mirrors
 
       - name: Run the tool
-        run: ./ci-mirrors
+        run: ./ci-mirrors upload
 
   finished:
     name: Build finished
     runs-on: ubuntu-latest
-    needs: [build, apply]
+    needs: [ build, apply ]
     if: "${{ !cancelled() }}"
     env:
       NEEDS: "${{ toJson(needs) }}"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ the TOML files in the `files/` directory. Each entry has the following schema:
   artifacts built from open source code you should put the license identifier,
   for everything else you should put a link to the licensing terms.
 
+You can add a new entry either by manually modifying a TOML file in the `files` directory,
+or by using the following command:
+
+```bash
+$ cargo run -- add-file <source-url> --path <cdn-name> --toml-files <path-to-toml-file> [--license <license>]
+```
+
 Once the PR is merged, the file will be available at:
 
 ```

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,11 @@
+use sha2::{Digest, Sha256};
+
+pub fn to_hex(sha: &Sha256) -> String {
+    let sha = sha.clone().finalize();
+    let bytes = sha.as_slice();
+    let mut result = String::new();
+    for byte in bytes {
+        result.push_str(&format!("{byte:0<2x}"));
+    }
+    result
+}


### PR DESCRIPTION
Some people might not know how to quickly compute a SHA256 hash. This command automates the process of adding new mirrored entries to the TOML files.