### PR TITLE
Fix uploading intel SDE

### DIFF
--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -21,7 +21,9 @@ impl Downloader {
     pub(crate) fn new() -> Result<Self, Error> {
         Ok(Self {
             storage: TempDir::new()?,
-            http: Client::new(),
+            http: Client::builder()
+                .user_agent("https://github.com/rust-lang/ci-mirrors")
+                .build()?,
         })
     }
 


### PR DESCRIPTION
This PR sets the user agent when downloading files, fixing the failure we saw in #13. It also adds the response body to the error message, which will help debugging similar issues in the future.