### PR TITLE
Add binutils-2.40

### DIFF
--- a/files/rustc/gnu.toml
+++ b/files/rustc/gnu.toml
@@ -1,4 +1,10 @@
 [[files]]
+name = "rustc/binutils-2.40.tar.bz2"
+source = "https://sourceware.org/pub/binutils/releases/binutils-2.40.tar.bz2"
+sha256 = "f8298eb153a4b37d112e945aa5cb2850040bcf26a3ea65b5a715c83afe05e48a"
+license = "GNU General Public License"
+
+[[files]]
 name = "rustc/binutils-2.44.tar.xz"
 source = "https://sourceware.org/pub/binutils/releases/binutils-2.44.tar.xz"
 sha256 = "ce2017e059d63e67ddb924e09d4ec49c2893605035cd60e92ad53177f4377237"


### PR DESCRIPTION
Used by freebsd-toolchain.sh here: https://github.com/rust-lang/rust/blob/b1b26b834d85e84b46aa8f8f3ce210a1627aa85f/src/ci/docker/scripts/freebsd-toolchain.sh#L31

ftp.gnu.org being down again failed https://github.com/rust-lang/rust/pull/145298 yesterday.