### PR TITLE
Mirror GCC 9.5.0 and add validation against paths starting with a slash

### DIFF
--- a/files/rustc/gcc.toml
+++ b/files/rustc/gcc.toml
@@ -17,7 +17,7 @@ sha256 = "ab642492f5cf882b74aa0cb730cd410a81edcdbec895183ce930e706c1c759b8"
 license = "GNU General Public License"
 
 [[files]]
-name = "/rustc/gcc/gcc-9.2.0.tar.xz"
+name = "rustc/gcc/gcc-9.2.0.tar.xz"
 sha256 = "ea6ef08f121239da5695f76c9b33637a118dcf63e24164422231917fa61fb206"
 source = "https://ftp.gnu.org/gnu/gcc/gcc-9.2.0/gcc-9.2.0.tar.xz"
 license = "GNU General Public License"

--- a/files/rustc/gcc.toml
+++ b/files/rustc/gcc.toml
@@ -21,3 +21,9 @@ name = "rustc/gcc/gcc-9.2.0.tar.xz"
 sha256 = "ea6ef08f121239da5695f76c9b33637a118dcf63e24164422231917fa61fb206"
 source = "https://ftp.gnu.org/gnu/gcc/gcc-9.2.0/gcc-9.2.0.tar.xz"
 license = "GNU General Public License"
+
+[[files]]
+name = "rustc/gcc/gcc-9.5.0.tar.xz"
+sha256 = "27769f64ef1d4cd5e2be8682c0c93f9887983e6cfd1a927ce5a0a2915a95cf8f"
+source = "https://ftp.gnu.org/gnu/gcc/gcc-9.5.0/gcc-9.5.0.tar.xz"
+license = "GNU General Public License"

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -99,6 +99,16 @@ pub(crate) fn load_manifests(load_from: &Path) -> Result<(Vec<MirrorFile>, Vec<S
                             rename_from: managed.rename_from,
                         },
                     };
+                    if mirror_file.name.starts_with('/') {
+                        emit_error(
+                            "Mirrored path cannot start with a slash (/)".to_string(),
+                            &mirror_file,
+                            &file_source,
+                            cache,
+                            errors,
+                        );
+                    }
+
                     if let Source::Url(ref source) = mirror_file.source {
                         if let Some(file_name) = source.path().split('/').last()
                             && let Some(path_name) = mirror_file.name.split('/').last()


### PR DESCRIPTION
Context: https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/unsoundness.20in.20x86-64-linux.20dist.20bootstrap.20chain/with/560099861

The 9.2.0 archive starting with a slash should be removed from the S3 bucket, ideally :see_no_evil: