### PR TITLE
ci: add known-good kernel versions for CT-NG 1.28.0

### DIFF
--- a/files/rustc/kernel.toml
+++ b/files/rustc/kernel.toml
@@ -39,3 +39,15 @@ name = "rustc/linux-5.19.17.tar.gz"
 sha256 = "fbfd02954bea5cf3e01a6e5b25423bfc6ad898bf95d32699d03aa456e777ff4c"
 source = "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/snapshot/linux-5.19.17.tar.gz"
 license = "GPL-2.0"
+
+[[files]]
+name = "rustc/linux-3.2.101.tar.gz"
+sha256 = "93e8391e029f131d5ba4b7ad76cc34b12f2c2244059604042f2297c4bde093f7"
+source = "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/snapshot/linux-3.2.101.tar.gz"
+license = "GPL-2.0"
+
+[[files]]
+name = "rustc/linux-5.19.16.tar.gz"
+sha256 = "bbf0ead65559250e0784c13d4f9716b7f917a1d3a4e00f671f3994cc6990bb02"
+source = "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/snapshot/linux-5.19.16.tar.gz"
+license = "GPL-2.0"


### PR DESCRIPTION
See [#t-infra > kernel.org is borked @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/kernel.2Eorg.20is.20borked/near/608189164)

Apparently CT-NG 1.28.0 has known-good versions of:

- 3.2.101 versus 3.2.102 (latest)
- 5.19.16 versus 5.19.17 (latest)