### PR TITLE
Document rust-lang/rust CI artifact naming conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,19 @@ need to do so, please ask the infra team on Zulip.
 >
 > Storage space in ci-mirrors is not a concern. If you need to upload a new
 > version of a file, add it separately without deleting the old one.
+
+## Naming conventions
+
+### Artifacts used by `rust-lang/rust` CI
+
+For artifacts used by `rust-lang/rust` CI, they should adopt the following
+naming convention:
+
+* If the artifact is used by `crosstools-ng` ("CT-NG"), then CT-NG's mirror
+  artifact search logic requires the artifact to be directly available under
+  `rustc/`.
+  * Example: `rustc/linux-3.2.101.tar.gz` (the archive is used by CT-NG).
+* If the artifact is used "ordinarily" and not by CT-NG, then the artifact
+  should be made available at preferably a "namespaced" path such as
+  `rustc/busybox/`.
+  * Example: `rustc/busybox/busybox-1.2.3.tar.bz2`.


### PR DESCRIPTION
## Summary

It is my understanding as well that `rustc/` prefix for artifact name by convention means that it is used by rust-lang/rust CI. So actually document this to make it explicit.

cf. https://github.com/rust-lang/ci-mirrors/pull/47#pullrequestreview-4631043733.